### PR TITLE
Minor Bug Fixes for pandas==2.2.3

### DIFF
--- a/clumpsptm/mapping/ref.py
+++ b/clumpsptm/mapping/ref.py
@@ -135,7 +135,7 @@ def get_blast_hits_with_sifts(
 
         res.append(_res)
 
-    return pd.concat(res,1).T.set_index("query")
+    return pd.concat(res,axis=1).T.set_index("query")
 
 def get_blast_hits_with_alphafold(
     blasted_files: list,
@@ -197,7 +197,7 @@ def get_blast_hits_with_alphafold(
 
         res.append(_res)
 
-    return pd.concat(res,1).T.set_index("query")
+    return pd.concat(res,axis=1).T.set_index("query")
 
 def get_pdb_match(sifts_s, acc_df, pdbstore):
     """
@@ -322,7 +322,7 @@ def get_pdb_matches(
                 except:
                     print("Error loading: {}-{}".format(row["PDB"], row["CHAIN"]))
 
-            resd = pd.concat(resd,1)
+            resd = pd.concat(resd,axis=1)
             sifts_filt_df['proteins'] = acc
             sifts_filt_df = sifts_filt_df.astype(str)
 

--- a/clumpsptm/utils.py
+++ b/clumpsptm/utils.py
@@ -79,7 +79,7 @@ def add_corrected_fdr(results_df: pd.DataFrame, thresh_num: float = 0.1, weight_
         else:
             _df_sam['fdr_thresh'] = thresh_num
             _df_sam['fdr_pass'] = _df_sam['fdr_max_pval'] <= thresh_num
-        _df_sam['fdr_corr'] = 1
+        _df_sam['fdr_corr'] = 1.0
 
         _,_df_sam.loc[_df_sam['fdr_pass'],'fdr_corr'],_,_ = multipletests(
             _df_sam[_df_sam['fdr_pass']]['clumpsptm_pval'], method='fdr_bh',


### PR DESCRIPTION
In `pd.concat()`, the `axis` argument now needs to be set explicitly (required as of pandas 0.23.0).
Also, I changed the placeholder for `_df_sam['fdr_corr']` to a float, to silence a warning about overwriting an int with a float.