### PR TITLE
Added new ValueError() exception to generate_clumpsptm_output()

### DIFF
--- a/clumpsptm/utils.py
+++ b/clumpsptm/utils.py
@@ -211,4 +211,7 @@ def generate_clumpsptm_output(
     if len(res_df) == 0:
         raise ValueError('NO RESULTS FILES FOUND.')
 
+    if all(v is None for v in res_df):
+        raise ValueError('NO VALID RESULTS FOUND AFTER FILTERING.')
+
     return pd.concat(res_df)


### PR DESCRIPTION
This error specifically catches empty dataframes as a result of filtering from `_collapse_sites()`, even though results-files existed. I run into this somewhat frequently while running with the `--test` flag, so an explicit error is useful.